### PR TITLE
Add script to build and zip Angular app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Angular With Codex
+
+## Helper Scripts
+
+This repository includes a PowerShell script that builds the Angular application and creates a ZIP archive of the published files.
+
+### Usage
+
+```powershell
+pwsh ./scripts/build-and-publish.ps1 -Configuration prod -ZipName publish.zip
+```
+
+The script installs dependencies, runs the Angular build for the specified configuration, and then archives the `dist/employee-app` output into `publish.zip`. Archive entries use forward slashes so the ZIP can be extracted consistently on any platform.

--- a/scripts/build-and-publish.ps1
+++ b/scripts/build-and-publish.ps1
@@ -1,0 +1,38 @@
+# Build and publish the Angular app then create a zip archive
+param(
+    [string]$Configuration = "prod",
+    [string]$ZipName = "publish.zip"
+)
+
+$ErrorActionPreference = 'Stop'
+
+$root = Split-Path -Parent $PSScriptRoot
+$projectRoot = Join-Path $root 'employee-app'
+
+Push-Location $projectRoot
+try {
+    npm install --no-audit --no-fund
+    npx ng build --configuration $Configuration
+} finally {
+    Pop-Location
+}
+
+$distDir = Join-Path $projectRoot 'dist/employee-app'
+if (!(Test-Path $distDir)) {
+    Write-Error "Build output directory not found: $distDir"
+    exit 1
+}
+
+$zipPath = Join-Path $root $ZipName
+if (Test-Path $zipPath) { Remove-Item $zipPath -Force }
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$zip = [IO.Compression.ZipFile]::Open($zipPath, [IO.Compression.ZipArchiveMode]::Create)
+
+Get-ChildItem -Path $distDir -Recurse | Where-Object { -not $_.PSIsContainer } | ForEach-Object {
+    $relativePath = $_.FullName.Substring($distDir.Length + 1) -replace '\\','/'
+    [IO.Compression.ZipFileExtensions]::CreateEntryFromFile($zip, $_.FullName, $relativePath) | Out-Null
+}
+
+$zip.Dispose()
+Write-Host "Archive created at $zipPath"


### PR DESCRIPTION
## Summary
- add helper PowerShell script for building and publishing
- document usage in README

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866122106ec832d9b1be0269b878d7f