### PR TITLE
Fix npx invocation for serve-with-browser script

### DIFF
--- a/scripts/serve-with-browser.ps1
+++ b/scripts/serve-with-browser.ps1
@@ -12,7 +12,8 @@ $projectRoot = Join-Path $root 'employee-app'
 Push-Location $projectRoot
 try {
     npm install --no-audit --no-fund
-    $serveProcess = Start-Process -FilePath 'npx' -ArgumentList @('ng','serve','--configuration',$Configuration,'--no-open') -NoNewWindow -PassThru
+    $npx = if ($IsWindows) { 'npx.cmd' } else { 'npx' }
+    $serveProcess = Start-Process -FilePath $npx -ArgumentList @('ng','serve','--configuration',$Configuration,'--no-open') -NoNewWindow -PassThru
 } finally {
     Pop-Location
 }


### PR DESCRIPTION
## Summary
- improve PowerShell script to resolve `npx` launcher on Windows

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68661aae947c832daa4bdc2cc772c4f1