### PR TITLE
Fix build errors by registering dialog component

### DIFF
--- a/employee-app/src/app/app.module.ts
+++ b/employee-app/src/app/app.module.ts
@@ -11,12 +11,13 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
 
 import { AppComponent } from './app.component';
-import { EmployeesComponent } from './employees/employees.component';
+import { EmployeesComponent, EmployeeDialog } from './employees/employees.component';
 
 @NgModule({
-  declarations: [AppComponent, EmployeesComponent],
+  declarations: [AppComponent, EmployeesComponent, EmployeeDialog],
   imports: [
     BrowserModule,
     BrowserAnimationsModule,
@@ -30,6 +31,7 @@ import { EmployeesComponent } from './employees/employees.component';
     MatTableModule,
     MatDialogModule,
     MatInputModule,
+    MatFormFieldModule,
   ],
   bootstrap: [AppComponent],
 })

--- a/employee-app/src/app/employees/employees.component.ts
+++ b/employee-app/src/app/employees/employees.component.ts
@@ -84,7 +84,7 @@ export class EmployeesComponent implements OnInit {
 
 @Component({
   selector: 'employee-dialog',
-  templateUrl: 'employee-dialog.html'
+  templateUrl: './employee-dialog.html'
 })
 export class EmployeeDialog {
   form: FormGroup;


### PR DESCRIPTION
## Summary
- register `EmployeeDialog` with the app module
- add missing `MatFormFieldModule`
- ensure `EmployeeDialog` template uses relative path

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68661ba04424832d8d0c90fb78ed3617