### PR TITLE
Refactor layout with modular components

### DIFF
--- a/employee-app/src/app/app-routing.module.ts
+++ b/employee-app/src/app/app-routing.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { EmployeesComponent } from './employees/employees.component';
+import { DepartmentsComponent } from './departments/departments.component';
+import { HealthComponent } from './health/health.component';
+
+const routes: Routes = [
+  { path: '', redirectTo: 'employees', pathMatch: 'full' },
+  { path: 'employees', component: EmployeesComponent },
+  { path: 'departments', component: DepartmentsComponent },
+  { path: 'health', component: HealthComponent },
+  { path: '**', redirectTo: 'employees' }
+];
+
+@NgModule({
+  imports: [RouterModule.forRoot(routes)],
+  exports: [RouterModule]
+})
+export class AppRoutingModule {}

--- a/employee-app/src/app/app.component.html
+++ b/employee-app/src/app/app.component.html
@@ -1,8 +1,1 @@
-<div class="container">
-  <header>Header</header>
-  <nav>Left Sidebar</nav>
-  <main>
-    <app-employees></app-employees>
-  </main>
-  <footer>Footer</footer>
-</div>
+<app-layout></app-layout>

--- a/employee-app/src/app/app.component.ts
+++ b/employee-app/src/app/app.component.ts
@@ -1,11 +1,11 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { EmployeesComponent } from './employees/employees.component';
+import { LayoutComponent } from './layout/layout.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [CommonModule, EmployeesComponent],
+  imports: [CommonModule, LayoutComponent],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })

--- a/employee-app/src/app/app.module.ts
+++ b/employee-app/src/app/app.module.ts
@@ -3,18 +3,8 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientModule } from '@angular/common/http';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-
-import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatSidenavModule } from '@angular/material/sidenav';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
-import { MatTableModule } from '@angular/material/table';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatInputModule } from '@angular/material/input';
-import { MatFormFieldModule } from '@angular/material/form-field';
-
+import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
-import { EmployeesComponent, EmployeeDialog } from './employees/employees.component';
 
 @NgModule({
   declarations: [],
@@ -24,17 +14,8 @@ import { EmployeesComponent, EmployeeDialog } from './employees/employees.compon
     HttpClientModule,
     FormsModule,
     ReactiveFormsModule,
-    MatToolbarModule,
-    MatSidenavModule,
-    MatButtonModule,
-    MatIconModule,
-    MatTableModule,
-    MatDialogModule,
-    MatInputModule,
-    MatFormFieldModule,
+    AppRoutingModule,
     AppComponent,
-    EmployeesComponent,
-    EmployeeDialog,
   ],
   bootstrap: [AppComponent],
 })

--- a/employee-app/src/app/departments/departments.component.ts
+++ b/employee-app/src/app/departments/departments.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-departments',
+  standalone: true,
+  imports: [CommonModule],
+  template: '<p>Departments works!</p>'
+})
+export class DepartmentsComponent {}

--- a/employee-app/src/app/employees/employees.component.css
+++ b/employee-app/src/app/employees/employees.component.css
@@ -1,7 +1,20 @@
 .actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
   margin-bottom: 1rem;
+}
+
+.search {
+  margin-left: auto;
 }
 
 .table-actions {
   display: flex;
+  gap: 0.5rem;
+}
+
+.full-width {
+  width: 100%;
 }

--- a/employee-app/src/app/employees/employees.component.html
+++ b/employee-app/src/app/employees/employees.component.html
@@ -5,19 +5,23 @@
     <input type="file" hidden (change)="importExcel($event)" #fileInput />
     <button mat-raised-button (click)="fileInput.click()">Import from Excel</button>
   </label>
+  <mat-form-field appearance="outline" class="search">
+    <mat-label>Search</mat-label>
+    <input matInput [formControl]="search" placeholder="Search" />
+  </mat-form-field>
 </div>
 
-<table mat-table [dataSource]="employees" class="mat-elevation-z8">
+<table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8 full-width">
   <ng-container matColumnDef="name">
-    <th mat-header-cell *matHeaderCellDef>Name</th>
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>Name</th>
     <td mat-cell *matCellDef="let element">{{element.name}}</td>
   </ng-container>
   <ng-container matColumnDef="email">
-    <th mat-header-cell *matHeaderCellDef>Email</th>
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>Email</th>
     <td mat-cell *matCellDef="let element">{{element.email}}</td>
   </ng-container>
   <ng-container matColumnDef="phone">
-    <th mat-header-cell *matHeaderCellDef>Phone</th>
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>Phone</th>
     <td mat-cell *matCellDef="let element">{{element.phone}}</td>
   </ng-container>
   <ng-container matColumnDef="actions">
@@ -33,7 +37,10 @@
   </ng-container>
 
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+  <tr class="mat-row" *matNoDataRow>
+    <td class="mat-cell" colspan="4">No employees found.</td>
+  </tr>
 </table>
 
-<ng-template></ng-template>
+<mat-paginator [pageSize]="5" [pageSizeOptions]="[5, 10, 20]"></mat-paginator>

--- a/employee-app/src/app/health/health.component.ts
+++ b/employee-app/src/app/health/health.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-health',
+  standalone: true,
+  imports: [CommonModule],
+  template: '<p>Health works!</p>'
+})
+export class HealthComponent {}

--- a/employee-app/src/app/layout/footer.component.ts
+++ b/employee-app/src/app/layout/footer.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-footer',
+  standalone: true,
+  imports: [CommonModule],
+  template: `<footer>&copy; 2024</footer>`
+})
+export class FooterComponent {}

--- a/employee-app/src/app/layout/header.component.ts
+++ b/employee-app/src/app/layout/header.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatToolbarModule } from '@angular/material/toolbar';
+
+@Component({
+  selector: 'app-header',
+  standalone: true,
+  imports: [CommonModule, MatToolbarModule],
+  template: `<header><mat-toolbar color="primary">Employee App</mat-toolbar></header>`
+})
+export class HeaderComponent {}

--- a/employee-app/src/app/layout/layout.component.css
+++ b/employee-app/src/app/layout/layout.component.css
@@ -1,0 +1,39 @@
+.layout-container {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  grid-template-rows: auto 1fr auto;
+  min-height: 100vh;
+}
+
+header {
+  grid-column: 1 / -1;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+nav {
+  position: sticky;
+  top: 64px;
+  height: calc(100vh - 64px);
+  overflow-y: auto;
+  background: #f5f5f5;
+}
+
+main {
+  padding: 1rem;
+}
+
+footer {
+  grid-column: 1 / -1;
+  position: sticky;
+  bottom: 0;
+  background-color: #1976d2;
+  color: white;
+  text-align: center;
+  padding: 1rem;
+}
+
+.active-link {
+  font-weight: bold;
+}

--- a/employee-app/src/app/layout/layout.component.html
+++ b/employee-app/src/app/layout/layout.component.html
@@ -1,0 +1,8 @@
+<div class="layout-container">
+  <app-header></app-header>
+  <app-sidebar></app-sidebar>
+  <main>
+    <router-outlet></router-outlet>
+  </main>
+  <app-footer></app-footer>
+</div>

--- a/employee-app/src/app/layout/layout.component.ts
+++ b/employee-app/src/app/layout/layout.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterOutlet } from '@angular/router';
+import { HeaderComponent } from './header.component';
+import { SidebarComponent } from './sidebar.component';
+import { FooterComponent } from './footer.component';
+
+@Component({
+  selector: 'app-layout',
+  standalone: true,
+  imports: [CommonModule, RouterOutlet, HeaderComponent, SidebarComponent, FooterComponent],
+  templateUrl: './layout.component.html',
+  styleUrls: ['./layout.component.css']
+})
+export class LayoutComponent {}

--- a/employee-app/src/app/layout/sidebar.component.ts
+++ b/employee-app/src/app/layout/sidebar.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { MatListModule } from '@angular/material/list';
+
+@Component({
+  selector: 'app-sidebar',
+  standalone: true,
+  imports: [CommonModule, RouterModule, MatListModule],
+  template: `
+    <nav>
+      <mat-nav-list>
+        <a mat-list-item routerLink="/employees" routerLinkActive="active-link">Employees</a>
+        <a mat-list-item routerLink="/departments" routerLinkActive="active-link">Departments</a>
+        <a mat-list-item routerLink="/health" routerLinkActive="active-link">Health</a>
+      </mat-nav-list>
+    </nav>
+  `
+})
+export class SidebarComponent {}

--- a/employee-app/src/app/shared/confirm-dialog.component.ts
+++ b/employee-app/src/app/shared/confirm-dialog.component.ts
@@ -1,0 +1,24 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-confirm-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  template: `
+    <h2 mat-dialog-title>Confirm</h2>
+    <mat-dialog-content>{{ data }}</mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button (click)="dialogRef.close(false)">Cancel</button>
+      <button mat-button color="warn" (click)="dialogRef.close(true)">Delete</button>
+    </mat-dialog-actions>
+  `
+})
+export class ConfirmDialogComponent {
+  constructor(
+    public dialogRef: MatDialogRef<ConfirmDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: string
+  ) {}
+}

--- a/employee-app/src/styles.css
+++ b/employee-app/src/styles.css
@@ -3,30 +3,19 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
-header, footer {
-  padding: 1rem;
+header {
   background-color: #1976d2;
   color: white;
-  text-align: center;
-}
-
-.container {
-  display: grid;
-  grid-template-columns: 200px 1fr;
-  grid-template-rows: auto 1fr auto;
-  height: 100vh;
 }
 
 nav {
-  padding: 1rem;
-  background: #f5f5f5;
-}
-
-main {
   padding: 1rem;
 }
 
 .table-actions button {
   margin-right: 0.5rem;
 }
-.w-100 { width: 100%; }
+
+.w-100 {
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
- create standalone layout components (header, sidebar, footer)
- add routing module and placeholder department/health pages
- refactor root component to use layout
- enhance employees page with search, sort, pagination and confirm dialog
- clean up global styles

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_686633a3f0f4832db65d27bebe105557