### PR TITLE
Fix incorrect employees API endpoint

### DIFF
--- a/employee-app/src/app/services/employees.service.ts
+++ b/employee-app/src/app/services/employees.service.ts
@@ -6,7 +6,7 @@ import { environment } from '../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class EmployeesService {
-  private apiUrl = `${environment.apiBaseUrl}/employees`;
+  private apiUrl = `${environment.apiBaseUrl}/api/employees`;
 
   constructor(private http: HttpClient) {}
 


### PR DESCRIPTION
## Summary
- fix base path for employees API

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68663511269c832dbbd7d585914bcec7