### PR TITLE
Implement entity page layouts

### DIFF
--- a/employee-app/src/app/departments/department-dialog.html
+++ b/employee-app/src/app/departments/department-dialog.html
@@ -1,0 +1,13 @@
+<h1 mat-dialog-title>Department</h1>
+<div mat-dialog-content>
+  <form [formGroup]="form">
+    <mat-form-field appearance="fill" class="w-100">
+      <mat-label>Department</mat-label>
+      <input matInput formControlName="department" />
+    </mat-form-field>
+  </form>
+</div>
+<div mat-dialog-actions>
+  <button mat-button (click)="cancel()">Cancel</button>
+  <button mat-button color="primary" (click)="submit()">Submit</button>
+</div>

--- a/employee-app/src/app/departments/departments.component.css
+++ b/employee-app/src/app/departments/departments.component.css
@@ -1,0 +1,20 @@
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.search {
+  margin-left: auto;
+}
+
+.table-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.full-width {
+  width: 100%;
+}

--- a/employee-app/src/app/departments/departments.component.html
+++ b/employee-app/src/app/departments/departments.component.html
@@ -1,0 +1,38 @@
+<div class="actions">
+  <button mat-raised-button color="primary" (click)="openAdd()">Add Department</button>
+  <button mat-raised-button (click)="exportExcel()">Export to Excel</button>
+  <label>
+    <input type="file" hidden (change)="importExcel($event)" #fileInput />
+    <button mat-raised-button (click)="fileInput.click()">Import from Excel</button>
+  </label>
+  <mat-form-field appearance="outline" class="search">
+    <mat-label>Search</mat-label>
+    <input matInput [formControl]="search" placeholder="Search" />
+  </mat-form-field>
+</div>
+
+<table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z8 full-width">
+  <ng-container matColumnDef="department">
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>Department</th>
+    <td mat-cell *matCellDef="let element">{{element.department}}</td>
+  </ng-container>
+  <ng-container matColumnDef="actions">
+    <th mat-header-cell *matHeaderCellDef></th>
+    <td mat-cell *matCellDef="let element" class="table-actions">
+      <button mat-icon-button color="accent" (click)="openEdit(element)">
+        <mat-icon>edit</mat-icon>
+      </button>
+      <button mat-icon-button color="warn" (click)="delete(element)">
+        <mat-icon>delete</mat-icon>
+      </button>
+    </td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+  <tr class="mat-row" *matNoDataRow>
+    <td class="mat-cell" colspan="2">No departments found.</td>
+  </tr>
+</table>
+
+<mat-paginator [pageSize]="5" [pageSizeOptions]="[5, 10, 20]"></mat-paginator>

--- a/employee-app/src/app/departments/departments.component.ts
+++ b/employee-app/src/app/departments/departments.component.ts
@@ -1,10 +1,161 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, AfterViewInit, ViewChild, Inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { DepartmentsService } from '../services/departments.service';
+import { Department } from '../models/department';
+import { MatDialog, MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MatTableModule, MatTableDataSource } from '@angular/material/table';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatSort, MatSortModule } from '@angular/material/sort';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule, FormsModule, FormControl } from '@angular/forms';
+import { debounceTime } from 'rxjs/operators';
+import * as XLSX from 'xlsx';
+import { ConfirmDialogComponent } from '../shared/confirm-dialog.component';
 
 @Component({
   selector: 'app-departments',
   standalone: true,
-  imports: [CommonModule],
-  template: '<p>Departments works!</p>'
+  imports: [
+    CommonModule,
+    MatTableModule,
+    MatButtonModule,
+    MatIconModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    ReactiveFormsModule,
+    MatPaginatorModule,
+    MatSortModule,
+  ],
+  templateUrl: './departments.component.html',
+  styleUrls: ['./departments.component.css']
 })
-export class DepartmentsComponent {}
+export class DepartmentsComponent implements OnInit, AfterViewInit {
+  displayedColumns = ['department', 'actions'];
+  dataSource = new MatTableDataSource<Department>([]);
+  search = new FormControl('');
+
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
+
+  constructor(private service: DepartmentsService, private dialog: MatDialog) {}
+
+  ngOnInit(): void {
+    this.load();
+    this.search.valueChanges.pipe(debounceTime(300)).subscribe(value => {
+      this.dataSource.filter = (value || '').trim().toLowerCase();
+    });
+  }
+
+  ngAfterViewInit(): void {
+    this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
+  }
+
+  load(): void {
+    this.service.getAll().subscribe({
+      next: data => (this.dataSource.data = data),
+      error: err => console.error(err)
+    });
+  }
+
+  openAdd(): void {
+    const dialogRef = this.dialog.open(DepartmentDialog, {
+      width: '300px',
+      data: {}
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.service.add(result).subscribe(() => this.load());
+      }
+    });
+  }
+
+  openEdit(dep: Department): void {
+    const dialogRef = this.dialog.open(DepartmentDialog, {
+      width: '300px',
+      data: { ...dep }
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.service.update(dep.id!, result).subscribe(() => this.load());
+      }
+    });
+  }
+
+  delete(dep: Department): void {
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      data: 'Delete department?'
+    });
+    dialogRef.afterClosed().subscribe(res => {
+      if (res) {
+        this.service.delete(dep.id!).subscribe(() => this.load());
+      }
+    });
+  }
+
+  importExcel(event: any): void {
+    const file = event.target.files[0];
+    const reader = new FileReader();
+    reader.onload = (e: any) => {
+      const data = new Uint8Array(e.target.result);
+      const workbook = XLSX.read(data, { type: 'array' });
+      const sheet = workbook.Sheets[workbook.SheetNames[0]];
+      const rows: Department[] = XLSX.utils.sheet_to_json(sheet);
+      rows.forEach(row => {
+        this.service.add(row).subscribe(() => this.load());
+      });
+    };
+    reader.readAsArrayBuffer(file);
+  }
+
+  exportExcel(): void {
+    const worksheet = XLSX.utils.json_to_sheet(this.dataSource.data);
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(workbook, worksheet, 'Departments');
+    XLSX.writeFile(workbook, 'departments.xlsx');
+  }
+}
+
+@Component({
+  selector: 'department-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+  ],
+  templateUrl: './department-dialog.html'
+})
+export class DepartmentDialog {
+  form: FormGroup;
+
+  constructor(
+    public dialogRef: MatDialogRef<DepartmentDialog>,
+    @Inject(MAT_DIALOG_DATA) public data: Department,
+    private fb: FormBuilder
+  ) {
+    this.form = this.fb.group({
+      department: [data.department, Validators.required],
+    });
+  }
+
+  submit(): void {
+    if (this.form.valid) {
+      this.dialogRef.close(this.form.value);
+    }
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/employee-app/src/app/health/health.component.css
+++ b/employee-app/src/app/health/health.component.css
@@ -1,0 +1,11 @@
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.full-width {
+  width: 100%;
+}

--- a/employee-app/src/app/health/health.component.html
+++ b/employee-app/src/app/health/health.component.html
@@ -1,0 +1,22 @@
+<div class="actions">
+  <button mat-raised-button color="primary" (click)="load()">Refresh</button>
+  <button mat-raised-button (click)="exportExcel()">Export to Excel</button>
+</div>
+
+<table mat-table [dataSource]="dataSource" class="mat-elevation-z8 full-width">
+  <ng-container matColumnDef="connectionString">
+    <th mat-header-cell *matHeaderCellDef>Connection String</th>
+    <td mat-cell *matCellDef="let element">{{element.connectionString}}</td>
+  </ng-container>
+  <ng-container matColumnDef="canConnect">
+    <th mat-header-cell *matHeaderCellDef>Can Connect</th>
+    <td mat-cell *matCellDef="let element">{{element.canConnect}}</td>
+  </ng-container>
+  <ng-container matColumnDef="exception">
+    <th mat-header-cell *matHeaderCellDef>Exception</th>
+    <td mat-cell *matCellDef="let element">{{element.exception}}</td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+</table>

--- a/employee-app/src/app/health/health.component.ts
+++ b/employee-app/src/app/health/health.component.ts
@@ -1,10 +1,39 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { HealthService } from '../services/health.service';
+import { HealthCheckResult } from '../models/health-check-result';
+import { MatTableModule } from '@angular/material/table';
+import { MatButtonModule } from '@angular/material/button';
+import * as XLSX from 'xlsx';
 
 @Component({
   selector: 'app-health',
   standalone: true,
-  imports: [CommonModule],
-  template: '<p>Health works!</p>'
+  imports: [CommonModule, MatTableModule, MatButtonModule],
+  templateUrl: './health.component.html',
+  styleUrls: ['./health.component.css']
 })
-export class HealthComponent {}
+export class HealthComponent implements OnInit {
+  displayedColumns = ['connectionString', 'canConnect', 'exception'];
+  dataSource: HealthCheckResult[] = [];
+
+  constructor(private service: HealthService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.service.getStatus().subscribe({
+      next: data => (this.dataSource = [data]),
+      error: err => console.error(err)
+    });
+  }
+
+  exportExcel(): void {
+    const worksheet = XLSX.utils.json_to_sheet(this.dataSource);
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(workbook, worksheet, 'Health');
+    XLSX.writeFile(workbook, 'health.xlsx');
+  }
+}

--- a/employee-app/src/app/models/department.ts
+++ b/employee-app/src/app/models/department.ts
@@ -1,0 +1,4 @@
+export interface Department {
+  id?: string;
+  department: string;
+}

--- a/employee-app/src/app/models/health-check-result.ts
+++ b/employee-app/src/app/models/health-check-result.ts
@@ -1,0 +1,8 @@
+import { Employee } from './employee';
+
+export interface HealthCheckResult {
+  connectionString?: string | null;
+  canConnect: boolean;
+  employees?: Employee[] | null;
+  exception?: string | null;
+}

--- a/employee-app/src/app/services/departments.service.ts
+++ b/employee-app/src/app/services/departments.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Department } from '../models/department';
+import { environment } from '../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class DepartmentsService {
+  private apiUrl = `${environment.apiBaseUrl}/api/departments`;
+
+  constructor(private http: HttpClient) {}
+
+  getAll(): Observable<Department[]> {
+    return this.http.get<Department[]>(this.apiUrl);
+  }
+
+  add(department: Department): Observable<Department> {
+    return this.http.post<Department>(this.apiUrl, department);
+  }
+
+  update(id: string, department: Department): Observable<void> {
+    return this.http.put<void>(`${this.apiUrl}/${id}`, department);
+  }
+
+  delete(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/${id}`);
+  }
+}

--- a/employee-app/src/app/services/health.service.ts
+++ b/employee-app/src/app/services/health.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { HealthCheckResult } from '../models/health-check-result';
+import { environment } from '../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class HealthService {
+  private apiUrl = `${environment.apiBaseUrl}/api/Health`;
+
+  constructor(private http: HttpClient) {}
+
+  getStatus(): Observable<HealthCheckResult> {
+    return this.http.get<HealthCheckResult>(this.apiUrl);
+  }
+}


### PR DESCRIPTION
## Summary
- add models for department and health check result
- create services for departments and health endpoints
- implement DepartmentsComponent with table, dialog, and Excel import/export
- flesh out HealthComponent with table view and Excel export

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_686641c4e348832dad50e6cae8d44ab9