### PR TITLE
Fix Azure deployment runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The script installs dependencies, runs the Angular build for the specified confi
 
 ### Deploy to Azure
 
-Use the `deploy-to-azure.ps1` script to build the Angular project with the default `dev` configuration and push the static content to an Azure App Service. The script assumes the resource group and app service plan already exist and will create the web app if needed.
+Use the `deploy-to-azure.ps1` script to build the Angular project with the default `dev` configuration and push the static content to an Azure App Service. The script assumes the resource group and app service plan already exist and will create the web app if needed. The deploy script targets the Node 20 runtime and uses `az webapp deploy` to publish a ZIP archive.
 
 ```powershell
 pwsh ./scripts/deploy-to-azure.ps1

--- a/scripts/deploy-to-azure.ps1
+++ b/scripts/deploy-to-azure.ps1
@@ -39,7 +39,9 @@ Get-ChildItem -Path $distDir -Recurse | Where-Object { -not $_.PSIsContainer } |
 $zip.Dispose()
 
 # Create the Web App and deploy the ZIP
-az webapp create --resource-group $ResourceGroup --plan $PlanName --name $WebAppName --runtime "node|20-lts" --query name -o tsv
-az webapp deployment source config-zip --resource-group $ResourceGroup --name $WebAppName --src $zipPath
+# The pipe character must be escaped for the underlying cmd process
+# so use `node^|20-lts` to specify the runtime version.
+az webapp create --resource-group $ResourceGroup --plan $PlanName --name $WebAppName --runtime node^|20-lts --query name -o tsv
+az webapp deploy --resource-group $ResourceGroup --name $WebAppName --src-path $zipPath
 
 Write-Host "Deployment complete: $WebAppName"


### PR DESCRIPTION
## Summary
- escape pipe character in `deploy-to-azure.ps1`
- use `az webapp deploy` and update README

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68666780bf4c832da65d7c5fd7877cae