### PR TITLE
Fix runtime quoting in Azure deployment script

### DIFF
--- a/scripts/deploy-to-azure.ps1
+++ b/scripts/deploy-to-azure.ps1
@@ -39,9 +39,8 @@ Get-ChildItem -Path $distDir -Recurse | Where-Object { -not $_.PSIsContainer } |
 $zip.Dispose()
 
 # Create the Web App and deploy the ZIP
-# The pipe character must be escaped for the underlying cmd process
-# so use `node^|20-lts` to specify the runtime version.
-az webapp create --resource-group $ResourceGroup --plan $PlanName --name $WebAppName --runtime node^|20-lts --query name -o tsv
+# Quote the runtime so the pipe character is passed correctly
+az webapp create --resource-group $ResourceGroup --plan $PlanName --name $WebAppName --runtime "node|20-lts" --query name -o tsv
 az webapp deploy --resource-group $ResourceGroup --name $WebAppName --src-path $zipPath
 
 Write-Host "Deployment complete: $WebAppName"


### PR DESCRIPTION
## Summary
- ensure the runtime value for `az webapp create` is quoted instead of escaped

## Testing
- `npm test` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_686669d5c990832d8a337f7a36582b89