### PR TITLE
Fix runtime string

### DIFF
--- a/scripts/deploy-to-azure.ps1
+++ b/scripts/deploy-to-azure.ps1
@@ -41,8 +41,8 @@ $zip.Dispose()
 Write-Output "start.. az webapp create "
 # Create the Web App and deploy the ZIP
 # Quote the runtime so the pipe character is passed correctly
-Write-Output "az webapp create --resource-group $ResourceGroup --plan $PlanName --name $WebAppName --runtime ""node|20-lts"" --query name -o tsv"
-az webapp create --resource-group $ResourceGroup --plan $PlanName --name $WebAppName --runtime "node:20-lts" --query name -o tsv
+Write-Output "az webapp create --resource-group $ResourceGroup --plan $PlanName --name $WebAppName --runtime \"node|20-lts\" --query name -o tsv"
+az webapp create --resource-group $ResourceGroup --plan $PlanName --name $WebAppName --runtime "node|20-lts" --query name -o tsv
 Write-Output "done.. az webapp create "
 Write-Output "****************************************************************************"
 Write-Output "start.. az webapp deploy  "


### PR DESCRIPTION
## Summary
- fix runtime string for Azure deployment script

## Testing
- `npx ng version` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6867ef504954832d88cffd784ac454f9