### PR TITLE
Fix parameter name to avoid PowerShell Host variable conflict

### DIFF
--- a/powershell-scripts/install-build-serve.ps1
+++ b/powershell-scripts/install-build-serve.ps1
@@ -1,7 +1,7 @@
 # Install dependencies, build the Angular app, and serve it locally
 param(
     [string]$Configuration = "dev",
-    [string]$Host = "localhost",
+    [string]$ServeHost = "localhost",
     [int]$Port = 4200
 )
 
@@ -14,7 +14,7 @@ Push-Location $projectRoot
 try {
     npm install --no-audit --no-fund
     npx ng build --configuration $Configuration
-    npx ng serve --host $Host --port $Port --open
+    npx ng serve --host $ServeHost --port $Port --open
 } finally {
     Pop-Location
 }


### PR DESCRIPTION
## Summary
- rename the `Host` parameter in `install-build-serve.ps1` to `ServeHost`

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6868b04a2768832da5382cd89957d78e