### PR TITLE
Update 7-Zip path in PowerShell scripts

### DIFF
--- a/powershell-scripts/deploy-eastasia-static-app.ps1
+++ b/powershell-scripts/deploy-eastasia-static-app.ps1
@@ -5,7 +5,7 @@ param(
     [string]$ResourceGroup = "eastasia-rg1",
     [string]$Location = "East Asia",
     [string]$ZipName = "publish.zip",
-    [string]$SevenZipPath = "7z"
+    [string]$SevenZipPath = 'C:\Program Files\7-Zip\7z.exe'
 )
 
 $ErrorActionPreference = 'Stop'

--- a/powershell-scripts/install-build-zip.ps1
+++ b/powershell-scripts/install-build-zip.ps1
@@ -2,7 +2,7 @@
 param(
     [string]$Configuration = "prod",
     [string]$ZipName = "publish.zip",
-    [string]$SevenZipPath = "7z"
+    [string]$SevenZipPath = 'C:\Program Files\7-Zip\7z.exe'
 )
 
 $ErrorActionPreference = 'Stop'


### PR DESCRIPTION
## Summary
- set default 7-Zip path to `C:\Program Files\7-Zip\7z.exe` in build scripts

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6868bd0680a0832d9bf37a76daa775c7