### PR TITLE
Fix Azure SWA deployment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ The script installs dependencies, runs the Angular build for the specified confi
 
 ### Deploy to Azure
 
+Ensure that the Azure Static Web Apps CLI extension is installed or updated so
+the `upload` command is available:
+
+```powershell
+az extension add --name staticwebapp
+```
+
 Run the `deploy-eastasia-static-app.ps1` script to build the Angular project and
 push the generated files to an Azure Static Web App. The script checks whether
 the static web app exists and creates it using `az staticwebapp create` if

--- a/powershell-scripts/deploy-eastasia-static-app.ps1
+++ b/powershell-scripts/deploy-eastasia-static-app.ps1
@@ -12,6 +12,13 @@ $ErrorActionPreference = 'Stop'
 
 $root = Split-Path -Parent $PSScriptRoot
 
+# Ensure the Azure Static Web Apps extension is installed
+$staticWebExt = az extension list --query "[?name=='staticwebapp']" -o tsv
+if (-not $staticWebExt) {
+    Write-Host "Installing Azure Static Web Apps extension..."
+    az extension add --name staticwebapp | Out-Null
+}
+
 # Build and archive the Angular project
 $buildScript = Join-Path $PSScriptRoot 'install-build-zip.ps1'
 Write-Host "Building Angular project and creating archive..."


### PR DESCRIPTION
## Summary
- check for the Azure Static Web Apps extension before deploying
- document installing the extension before running the deployment script

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868bde70ea0832d901ed005e9e8d259